### PR TITLE
Wait for server request to complete so UI test breakpoints work as expected

### DIFF
--- a/Sources/Mussel/MusselTester.swift
+++ b/Sources/Mussel/MusselTester.swift
@@ -28,7 +28,23 @@ extension MusselTester {
         request.httpBody = data
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let task = URLSession.shared.dataTask(with: request)
+        let dispatchGroup = DispatchGroup()
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                debugPrint("Mussel received error: \(error.localizedDescription)")
+            } else if let response = response as? HTTPURLResponse {
+                debugPrint("Mussel received response status code \(response.statusCode)")
+            } else {
+                debugPrint("Mussel request finished, but with an unexpected result. Maybe MusselServer isn't running?")
+            }
+            dispatchGroup.leave()
+        }
+
+        dispatchGroup.enter()
         task.resume()
+        
+        // Wait until the task completes
+        dispatchGroup.wait()
     }
 }


### PR DESCRIPTION
The problem I experienced is:

1. Set a breakpoint in your UI test right after a call to e.g. `MusselUniversalLinkTester.open(link)`
2. UI test runs until breakpoint is reached
3. Mussel Server never receives the request

This is caused by the fact that `URLRequest` does work in another queue once the task is resumed, and by setting a breakpoint directly after resuming the task, the other queue never performs the work. The fix is to have Mussel wait until the `URLRequest` task completes before returning. I did this using a `DispatchGroup`.

I also added some `debugPrint` calls so that when the request is complete, there's some evidence of it in the debug logs.