### PR TITLE
Support for "Simulator device set"

### DIFF
--- a/Sources/Mussel/MusselNotificationTester.swift
+++ b/Sources/Mussel/MusselNotificationTester.swift
@@ -3,15 +3,6 @@
 import Foundation
 
 public class MusselNotificationTester: MusselTester {
-    var targetAppBundleId: String
-    var serverHost: String = "localhost"
-    var serverPort: in_port_t = 10004
-    var serverEndpoint: String = "simulatorPush"
-
-    public required init(targetAppBundleId: String) {
-        self.targetAppBundleId = targetAppBundleId
-    }
-
     public func triggerSimulatorNotification(withMessage message: String, additionalKeys: [String: Any]? = nil) {
         var innerAlert: [String: Any] = ["alert": message]
         if let additionalKeys = additionalKeys {
@@ -22,14 +13,11 @@ public class MusselNotificationTester: MusselTester {
     }
 
     public func triggerSimulatorNotification(withFullPayload payload: [String: Any]) {
-        let endpoint = "http://\(serverHost):\(serverPort)/\(serverEndpoint)"
-
-        let json: [String: Any?] = [
-            "simulatorId": ProcessInfo.processInfo.environment["SIMULATOR_UDID"],
+        let options: [String: Any?] = [
             "appBundleId": targetAppBundleId,
             "pushPayload": payload,
         ]
 
-        serverRequest(endpoint: endpoint, json: json)
+        serverRequestTask("simulatorPush", options: options)
     }
 }

--- a/Sources/Mussel/MusselTester.swift
+++ b/Sources/Mussel/MusselTester.swift
@@ -5,12 +5,14 @@ import Foundation
 open class MusselTester {
     var targetAppBundleId: String
     private var simulatorId: String?
+    private var simulatorDeviceSet: String?
     var serverHost: String = "localhost"
     var serverPort: in_port_t = 10004
 
     public init(targetAppBundleId: String) {
         self.targetAppBundleId = targetAppBundleId
         self.simulatorId = ProcessInfo.processInfo.environment["SIMULATOR_UDID"]
+        self.simulatorDeviceSet = (ProcessInfo.processInfo.environment["HOME"]?.contains("XCTestDevices") ?? false) ? "testing" : nil
     }
 
     func serverRequestTask(_ task: String, options taskOptions: [String: Any?]) {
@@ -23,6 +25,7 @@ open class MusselTester {
 
         let requestOptions = taskOptions.merging([
             "simulatorId": self.simulatorId,
+            "simulatorDeviceSet": self.simulatorDeviceSet,
         ], uniquingKeysWith: { $1 })
 
         guard let data = try? JSONSerialization.data(withJSONObject: requestOptions, options: []) else {

--- a/Sources/Mussel/MusselTester.swift
+++ b/Sources/Mussel/MusselTester.swift
@@ -11,7 +11,11 @@ open class MusselTester {
 
     public init(targetAppBundleId: String) {
         self.targetAppBundleId = targetAppBundleId
+
         self.simulatorId = ProcessInfo.processInfo.environment["SIMULATOR_UDID"]
+
+        // Infer whether the "testing" set is in use.
+        // Instead of this, we could provide the path to the set, which is HOME truncated at the simulator ID.
         self.simulatorDeviceSet = (ProcessInfo.processInfo.environment["HOME"]?.contains("XCTestDevices") ?? false) ? "testing" : nil
     }
 

--- a/Sources/Mussel/MusselTester.swift
+++ b/Sources/Mussel/MusselTester.swift
@@ -2,24 +2,31 @@
 
 import Foundation
 
-protocol MusselTester: AnyObject {
-    var targetAppBundleId: String { get set }
-    var serverHost: String { get set }
-    var serverPort: in_port_t { get set }
-    var serverEndpoint: String { get set }
+open class MusselTester {
+    var targetAppBundleId: String
+    private var simulatorId: String?
+    var serverHost: String = "localhost"
+    var serverPort: in_port_t = 10004
 
-    init(targetAppBundleId: String)
-}
+    public init(targetAppBundleId: String) {
+        self.targetAppBundleId = targetAppBundleId
+        self.simulatorId = ProcessInfo.processInfo.environment["SIMULATOR_UDID"]
+    }
 
-extension MusselTester {
-    func serverRequest(endpoint: String, json: [String: Any?]) {
+    func serverRequestTask(_ task: String, options taskOptions: [String: Any?]) {
+        let endpoint = "http://\(serverHost):\(serverPort)/\(task)"
+
         guard let endpointUrl = URL(string: endpoint) else {
             print("Invalid endpoint URL: \(endpoint)")
             return
         }
 
-        guard let data = try? JSONSerialization.data(withJSONObject: json, options: []) else {
-            print("Invalid JSON: \(json)")
+        let requestOptions = taskOptions.merging([
+            "simulatorId": self.simulatorId,
+        ], uniquingKeysWith: { $1 })
+
+        guard let data = try? JSONSerialization.data(withJSONObject: requestOptions, options: []) else {
+            print("Invalid JSON: \(requestOptions)")
             return
         }
 

--- a/Sources/Mussel/MusselUniversalLinkTester.swift
+++ b/Sources/Mussel/MusselUniversalLinkTester.swift
@@ -3,23 +3,11 @@
 import Foundation
 
 public class MusselUniversalLinkTester: MusselTester {
-    var targetAppBundleId: String
-    var serverHost: String = "localhost"
-    var serverPort: in_port_t = 10004
-    var serverEndpoint: String = "simulatorUniversalLink"
-
-    public required init(targetAppBundleId: String) {
-        self.targetAppBundleId = targetAppBundleId
-    }
-
     public func open(_ link: String) {
-        let endpoint = "http://\(serverHost):\(serverPort)/\(serverEndpoint)"
-
-        let json: [String: Any?] = [
-            "simulatorId": ProcessInfo.processInfo.environment["SIMULATOR_UDID"],
+        let options: [String: Any?] = [
             "link": link,
         ]
 
-        serverRequest(endpoint: endpoint, json: json)
+        serverRequestTask("simulatorUniversalLink", options: options)
     }
 }


### PR DESCRIPTION
This is an attempt to address #24.

Mussel client infers the device set based on the `HOME` environment variable, which contains a path to the application within the Simulator. If it contains the string "XCTestDevices", then we use the device set name "testing". However, this could be changed to specify the path of the device set instead of the magic name "testing" by truncating it.

I changed the client to use a base class instead of protocol so that shared behavior can be written once. Identifying the current simulator ID and device set are in the base class. The base class implements the `serverRequest(task:options:)` method, and layers in these two items.

On the server, if a request includes the new option, it's used in the `simctl` command line. I also changed this to fail early if the weak `self` has gone away, rather than return a success status.